### PR TITLE
Fixed #320: sort streams based on resolution as it may not come sorted

### DIFF
--- a/app/specific/Play.js
+++ b/app/specific/Play.js
@@ -1109,6 +1109,18 @@ function Play_extractQualities(input) {
         } else tempCount++;
     }
 
+    //sort based on resolution as it may not come sorted
+    result.sort(function (a, b) {
+        if (!a || !b) {
+            return 0;
+        }
+        
+        var resA = parseInt(a.resolution.split('p')[0]);
+        var resB = parseInt(b.resolution.split('p')[0]);
+        
+        return resB - resA;
+    });
+
     return result;
 }
 


### PR DESCRIPTION
Since the quality of some streams is sorted randomly (issue #320), I have integrated the sorting based on the Android app.

Unfortunately, I cannot test the source code live on my Samsung TV, but it works externally. But feel free to test it again and take a look!